### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/aiw-devops/068b71b5-ed93-411b-9b64-aff20c2ea68d/854a9505-9fa2-4643-a5a5-9581e88e0de7/_apis/work/boardbadge/34a9992a-b5c3-419e-b124-47c975528e42)](https://dev.azure.com/aiw-devops/068b71b5-ed93-411b-9b64-aff20c2ea68d/_boards/board/t/854a9505-9fa2-4643-a5a5-9581e88e0de7/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#1874. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.